### PR TITLE
Fix knowledge texts class typo

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,7 @@
     <main>
         <section class="knowledge">
             <div class="knowledge__container container">
-                <div class="knowledege__texts">
+                <div class="knowledge__texts">
                     <h2 class="subtitle">Sobre Nosotros</h2>
                     <p class="knowledge__paragraph">Somos la principal Asociación de la Feria Libre de Melipilla, comprometida con el desarrollo, la organización y la representación de nuestros feriantes.</p>
                     <a href="Nosotros.html" class="cta">Conocer Más</a>


### PR DESCRIPTION
## Summary
- correct typo `knowledege__texts` to `knowledge__texts` in `index.html`

## Testing
- `grep -R "knowledge__texts" -n`

------
https://chatgpt.com/codex/tasks/task_b_685a06497f2c8330b74aed1a2d48b6f3