### PR TITLE
Add sliding mobile menu overlay

### DIFF
--- a/Directiva.html
+++ b/Directiva.html
@@ -59,6 +59,7 @@
             <button class="nav__toggle" aria-label="Abrir menú" aria-controls="main-menu" aria-expanded="false">
                 <span class="nav__icon nav__icon--open"></span>
             </button>
+            <div class="nav__overlay"></div>
         </nav>
 
         <section class="hero__container container">

--- a/Localizanos.html
+++ b/Localizanos.html
@@ -59,6 +59,7 @@
             <button class="nav__toggle" aria-label="Abrir menú" aria-controls="main-menu" aria-expanded="false">
                 <span class="nav__icon nav__icon--open"></span>
             </button>
+            <div class="nav__overlay"></div>
         </nav>
 
         <section class="hero__container container">

--- a/Nosotros.html
+++ b/Nosotros.html
@@ -59,6 +59,7 @@
             <button class="nav__toggle" aria-label="Abrir menú" aria-controls="main-menu" aria-expanded="false">
                 <span class="nav__icon nav__icon--open"></span>
             </button>
+            <div class="nav__overlay"></div>
         </nav>
 
         <section class="hero__container container">

--- a/Socios.html
+++ b/Socios.html
@@ -59,6 +59,7 @@
             <button class="nav__toggle" aria-label="Abrir menú" aria-controls="main-menu" aria-expanded="false">
                 <span class="nav__icon nav__icon--open"></span>
             </button>
+            <div class="nav__overlay"></div>
         </nav>
 
         <section class="hero__container container">

--- a/css/estilos - directiva.css
+++ b/css/estilos - directiva.css
@@ -520,3 +520,28 @@ body {
         */
     }
 }
+
+/* Mobile menu animation */
+.nav__link--menu {
+    transform: translateX(100%);
+    transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+.nav__link--show {
+    transform: translateX(0);
+    opacity: 1;
+}
+
+.nav__overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0,0,0,0.5);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s ease;
+}
+
+.nav__overlay--active {
+    opacity: 1;
+    pointer-events: auto;
+}

--- a/css/estilos - localizanos.css
+++ b/css/estilos - localizanos.css
@@ -510,3 +510,28 @@ body {
         */
     }
 }
+
+/* Mobile menu animation */
+.nav__link--menu {
+    transform: translateX(100%);
+    transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+.nav__link--show {
+    transform: translateX(0);
+    opacity: 1;
+}
+
+.nav__overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0,0,0,0.5);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s ease;
+}
+
+.nav__overlay--active {
+    opacity: 1;
+    pointer-events: auto;
+}

--- a/css/estilos - socios.css
+++ b/css/estilos - socios.css
@@ -520,3 +520,28 @@ body {
         */
     }
 }
+
+/* Mobile menu animation */
+.nav__link--menu {
+    transform: translateX(100%);
+    transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+.nav__link--show {
+    transform: translateX(0);
+    opacity: 1;
+}
+
+.nav__overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0,0,0,0.5);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s ease;
+}
+
+.nav__overlay--active {
+    opacity: 1;
+    pointer-events: auto;
+}

--- a/css/estilos-nosotros.css
+++ b/css/estilos-nosotros.css
@@ -682,3 +682,28 @@ body {
         */
     }
 }
+
+/* Mobile menu animation */
+.nav__link--menu {
+    transform: translateX(100%);
+    transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+.nav__link--show {
+    transform: translateX(0);
+    opacity: 1;
+}
+
+.nav__overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0,0,0,0.5);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s ease;
+}
+
+.nav__overlay--active {
+    opacity: 1;
+    pointer-events: auto;
+}

--- a/css/estilos.css
+++ b/css/estilos.css
@@ -3,6 +3,7 @@
     --color-title: #001A49;
 }
 
+
 #scrollUp {
     bottom: 20px;
     right: 20px;
@@ -520,4 +521,29 @@ body {
         width: 100%;
         */
     }
+}
+
+/* Mobile menu animation */
+.nav__link--menu {
+    transform: translateX(100%);
+    transition: transform 0.3s ease, opacity 0.3s ease;
+}
+
+.nav__link--show {
+    transform: translateX(0);
+    opacity: 1;
+}
+
+.nav__overlay {
+    position: fixed;
+    inset: 0;
+    background: rgba(0,0,0,0.5);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.3s ease;
+}
+
+.nav__overlay--active {
+    opacity: 1;
+    pointer-events: auto;
 }

--- a/index.html
+++ b/index.html
@@ -60,6 +60,7 @@
             <button class="nav__toggle" aria-label="Abrir menú" aria-controls="main-menu" aria-expanded="false">
                 <span class="nav__icon nav__icon--open"></span>
             </button>
+            <div class="nav__overlay"></div>
         </nav>
 
         <section class="hero__container container">

--- a/js/menu.js
+++ b/js/menu.js
@@ -2,14 +2,23 @@
     const openButton = document.querySelector('.nav__toggle[aria-controls="main-menu"]');
     const menu = document.getElementById('main-menu');
     const closeMenu = document.querySelector('.nav__toggle--close');
+    const overlay = document.querySelector('.nav__overlay');
 
     openButton.addEventListener('click', () => {
         menu.classList.add('nav__link--show');
+        overlay.classList.add('nav__overlay--active');
         openButton.setAttribute('aria-expanded', 'true');
     });
 
     closeMenu.addEventListener('click', () => {
         menu.classList.remove('nav__link--show');
+        overlay.classList.remove('nav__overlay--active');
+        openButton.setAttribute('aria-expanded', 'false');
+    });
+
+    overlay.addEventListener('click', () => {
+        menu.classList.remove('nav__link--show');
+        overlay.classList.remove('nav__overlay--active');
         openButton.setAttribute('aria-expanded', 'false');
     });
 })();


### PR DESCRIPTION
## Summary
- support overlay for nav menus
- start mobile menu off-screen
- toggle overlay from menu script

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685ad6a7ab788330b0c6bf9425294628