### PR TITLE
Add body nav-open class toggling

### DIFF
--- a/css/estilos - directiva.css
+++ b/css/estilos - directiva.css
@@ -16,6 +16,10 @@ body {
     font-family: 'Poppins', sans-serif;
 }
 
+body.nav-open {
+    overflow: hidden;
+}
+
 .container {
     width: 90%;
     max-width: 1200px;

--- a/css/estilos - localizanos.css
+++ b/css/estilos - localizanos.css
@@ -16,6 +16,10 @@ body {
     font-family: 'Poppins', sans-serif;
 }
 
+body.nav-open {
+    overflow: hidden;
+}
+
 .container {
     width: 90%;
     max-width: 1200px;

--- a/css/estilos - socios.css
+++ b/css/estilos - socios.css
@@ -16,6 +16,10 @@ body {
     font-family: 'Poppins', sans-serif;
 }
 
+body.nav-open {
+    overflow: hidden;
+}
+
 .container {
     width: 90%;
     max-width: 1200px;

--- a/css/estilos-nosotros.css
+++ b/css/estilos-nosotros.css
@@ -16,6 +16,10 @@ body {
     font-family: 'Poppins', sans-serif;
 }
 
+body.nav-open {
+    overflow: hidden;
+}
+
 .container {
     width: 90%;
     max-width: 1200px;

--- a/css/estilos.css
+++ b/css/estilos.css
@@ -13,8 +13,13 @@
     background-size: cover;
   }
 
+
 body {
     font-family: 'Poppins', sans-serif;
+}
+
+body.nav-open {
+    overflow: hidden;
 }
 
 .container {

--- a/js/menu.js
+++ b/js/menu.js
@@ -1,24 +1,33 @@
 (function(){
     const openButton = document.querySelector('.nav__toggle[aria-controls="main-menu"]');
     const menu = document.getElementById('main-menu');
-    const closeMenu = document.querySelector('.nav__toggle--close');
+    const closeButton = document.querySelector('.nav__toggle--close');
     const overlay = document.querySelector('.nav__overlay');
+    const body = document.body;
 
-    openButton.addEventListener('click', () => {
+    const openMenu = () => {
         menu.classList.add('nav__link--show');
         overlay.classList.add('nav__overlay--active');
         openButton.setAttribute('aria-expanded', 'true');
-    });
+        body.classList.add('nav-open');
+    };
 
-    closeMenu.addEventListener('click', () => {
+    const closeMenu = () => {
         menu.classList.remove('nav__link--show');
         overlay.classList.remove('nav__overlay--active');
         openButton.setAttribute('aria-expanded', 'false');
-    });
+        body.classList.remove('nav-open');
+    };
 
-    overlay.addEventListener('click', () => {
-        menu.classList.remove('nav__link--show');
-        overlay.classList.remove('nav__overlay--active');
-        openButton.setAttribute('aria-expanded', 'false');
+    openButton.addEventListener('click', openMenu);
+
+    closeButton.addEventListener('click', closeMenu);
+
+    overlay.addEventListener('click', closeMenu);
+
+    document.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape') {
+            closeMenu();
+        }
     });
 })();


### PR DESCRIPTION
## Summary
- prevent body scrolling when mobile menu is open
- toggle the `nav-open` class from the menu script
- close the menu with overlay click or Escape key

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685ad82cf3588330bc5c4a8ae6ffca68